### PR TITLE
Fix for DESCRIPTION tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function prepare(fileData, callback) {
 		var keys = line.split(":"),
 			isMultiLine = (line[0] === SPACE),
 			key = keys[0],
-			value = keys[1];
+			value = line.substr(keys[0].length+1);
 
 		prevKey = isMultiLine && prevKey || key;
 		switch(key) {


### PR DESCRIPTION
Sometimes we got an event with *DESCRIPTION* contains colon as below:

BEGIN:VEVENT
UID:calendar.855.field_calendar_dates.0
CREATED:20170120T174441Z
DESCRIPTION:Bingo every Tuesday and Friday\n11:00 am - 2:00 pm\nAt the Fran
 kfort Township Community Room\nCall for more information 815-806-2776
DTSTART;TZID=America/Chicago:20170502T110000
DTEND;TZID=America/Chicago:20170502T110000
LAST-MODIFIED:20170120T174441Z
SUMMARY:Senior Bingo
URL;TYPE=URI:http://www.frank.com/node/855
END:VEVENT

currently the parser split each line in two parts key and value , and its split by colon , so when we have multiple colons in the description line as above , the parser will take a part of it .
the fix is to take all the text after the first colon and set it in value variable 